### PR TITLE
Added method to post build info to a external web application fix #30

### DIFF
--- a/src/main/java/ContinuousIntegrationServer.java
+++ b/src/main/java/ContinuousIntegrationServer.java
@@ -1,3 +1,4 @@
+import javax.json.JsonObject;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.ServletException;
@@ -117,6 +118,18 @@ public class ContinuousIntegrationServer extends AbstractHandler {
         //TODO set variables
         //GitHubNotification.setStatus(commitStatus,gitTargetURL);
 
+    }
+    /**
+     * Modifies a JSONObject to include: commit SHA, link to commit, status, date, commitUser and log.
+     * Makes a post request to expr.link API endpoint inserting the data in database
+     * @param githubData A JSONObject based on a GitHub commit webhook.
+     * @return void
+     */
+    private void insertDB(JSONObject githubData) throws IOException, InterruptedException {
+        String targetURL = "https://expr-link.herokuapp.com/CI_Server";
+        JSONObject dbData = new JSONObject();
+        //TODO fill dbData with data, see HttpTest for requirements
+        Http.makePost(targetURL,githubData);
     }
 
     /**

--- a/src/main/java/Http.java
+++ b/src/main/java/Http.java
@@ -1,0 +1,32 @@
+import org.json.simple.JSONObject;
+
+import java.net.http.HttpClient;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+
+//HTTP class, contains makePost(post request url, json object)
+public class Http {
+    public static int makePost(String URL, JSONObject body) throws IOException, InterruptedException {
+        return postRequest(URL, body);
+    }
+
+
+
+    private static int postRequest(String URL, Object body) throws IOException, InterruptedException {
+
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(URL))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body.toString()))
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        return response.statusCode();
+
+
+    }
+}

--- a/src/main/java/Utils.java
+++ b/src/main/java/Utils.java
@@ -1,0 +1,19 @@
+import java.util.Random;
+//class to generate random string of length 50, used for testing HTTP post where SHA is needed.
+public class Utils {
+    String asciiUpperCase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    String asciiLowerCase = asciiUpperCase.toLowerCase();
+    String digits = "1234567890";
+    String seedChars = asciiUpperCase + asciiLowerCase + digits;
+    int length = 50;
+    public String generateRandomString() {
+        StringBuilder sb = new StringBuilder();
+        int i = 0;
+        Random rand = new Random();
+        while (i < length) {
+            sb.append(seedChars.charAt(rand.nextInt(seedChars.length())));
+            i++;
+        }
+        return sb.toString();
+    }
+}

--- a/src/test/java/HttpTest.java
+++ b/src/test/java/HttpTest.java
@@ -1,0 +1,42 @@
+import org.json.simple.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Random;
+
+import static org.junit.Assert.*;
+//TODO research appropiate testing method
+public class HttpTest {
+    Utils util = new Utils();
+
+    @Before
+    public void setUp() throws Exception {
+
+
+
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+    /**
+    Make a post request to the DB. responses is test by check code 200
+    The DB insertion can be verified by going to http://www.expr.link/builds/list/all. View Date for specific test.
+     **/
+    @Test
+    public void makePostDBInsert() throws IOException, InterruptedException {
+        String targetURL = "https://expr-link.herokuapp.com/CI_Server";
+        JSONObject body = new JSONObject();
+        String randomString = util.generateRandomString();
+        body.put("SHA",randomString);
+        body.put("status","pass");
+        body.put("link","https://github.com/LeeBadal/CI_webhook");
+        body.put("date", Instant.now().toString());
+        body.put("commiter","LeeTest");
+        body.put("log","big log this is what happened yada yada");
+        assertEquals(200,Http.makePost(targetURL,body));
+    }
+}


### PR DESCRIPTION
Make a post request to expr.link API endpoint and inserts a DB object to the database. The database content can be viewed at http://www.expr.link/builds/list/all